### PR TITLE
Add sneaker zoom

### DIFF
--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -34,13 +34,15 @@ const ShoeCard = ({
   return (
     <Link href={`/shoe/${slug}`}>
       <Wrapper>
-        <ImageWrapper>
-          <Image alt="" src={imageSrc} />
+        <ImageAndFlagWrapper>
+          <ImageWrapper>
+            <Image alt="" src={imageSrc} />
+          </ImageWrapper>
           {variant === 'on-sale' && <SaleFlag>Sale</SaleFlag>}
           {variant === 'new-release' && (
             <NewFlag>Just released!</NewFlag>
           )}
-        </ImageWrapper>
+        </ImageAndFlagWrapper>
         <Spacer size={12} />
         <Row>
           <Name>{name}</Name>
@@ -75,13 +77,24 @@ const Link = styled.a`
 
 const Wrapper = styled.article``;
 
-const ImageWrapper = styled.div`
+const ImageAndFlagWrapper = styled.div`
   position: relative;
+`;
+
+const ImageWrapper = styled.div`
+  overflow: hidden;
+  border-radius: 16px 16px 4px 4px;
+
+  // Remove <img> magic space because its inline
+  line-height: 0;
 `;
 
 const Image = styled.img`
   width: 100%;
-  border-radius: 16px 16px 4px 4px;
+
+  &:hover {
+    transform: scale(1.1) translateY(-4px);
+  }
 `;
 
 const Row = styled.div`

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -85,15 +85,18 @@ const ImageWrapper = styled.div`
   overflow: hidden;
   border-radius: 16px 16px 4px 4px;
 
-  // Remove <img> magic space because its inline
+  // Remove <img> magic space because it's inline
   line-height: 0;
 `;
 
 const Image = styled.img`
   width: 100%;
+  transform: scale(1) translateY(0);
+  transition: transform 500ms;
 
   &:hover {
     transform: scale(1.1) translateY(-4px);
+    transition: transform 200ms;
   }
 `;
 

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -93,6 +93,7 @@ const Image = styled.img`
   width: 100%;
   transform: scale(1) translateY(0);
   transition: transform 500ms;
+  will-change: transform;
 
   &:hover {
     transform: scale(1.1) translateY(-4px);


### PR DESCRIPTION
Add a zoom on the sneaker image on hover and make it animated.

- Zoom done with the `scale()` transform on zoom.
- `overflow: hidden;` to make the image fit in the designated space.
- Add an additional wrapper on the image to avoid cutting off flags with overflow from the negative margin.
- Move border-radius from `<img>` to wrapper.
- Animation on hover quicker than animation when hover is left.
- Add `will-change: transform;` to avoid CPU to GPU handoff for animation.