### PR TITLE
add animation to flag on shoe image hover 

### DIFF
--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled, { keyframes } from 'styled-components/macro';
 
 import { WEIGHTS } from '../../constants';
 import { formatPrice, pluralize, isNewShoe } from '../../utils';
@@ -92,15 +92,6 @@ const Image = styled.img`
   will-change: transform;
 `;
 
-const ImageAndFlagWrapper = styled.div`
-  position: relative;
-
-  &:hover ${Image} {
-    transform: scale(1.1) translateY(-4px);
-    transition: transform 200ms;
-  }
-`;
-
 const Row = styled.div`
   font-size: 1rem;
   display: flex;
@@ -145,6 +136,38 @@ const SaleFlag = styled(Flag)`
 `;
 const NewFlag = styled(Flag)`
   background-color: var(--color-secondary);
+`;
+
+const wiggle = keyframes`
+  0% {
+    transform: translateX(0);
+  }
+  15% {
+    transform: translateX(8px);
+  }
+  30% {
+    transform: translateX(0);
+  }
+  60% {
+    transform: translateX(8px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+`;
+
+const ImageAndFlagWrapper = styled.div`
+  position: relative;
+
+  &:hover ${Image} {
+    transform: scale(1.1) translateY(-4px);
+    transition: transform 200ms;
+  }
+
+  &:hover ${Flag} {
+    animation: ${wiggle} 1000ms;
+    animation-delay: 500ms;
+  }
 `;
 
 export default ShoeCard;

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -129,6 +129,8 @@ const Flag = styled.div`
   font-weight: ${WEIGHTS.bold};
   color: var(--color-white);
   border-radius: 2px;
+
+  will-change: transform;
 `;
 
 const SaleFlag = styled(Flag)`

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -164,9 +164,11 @@ const ImageAndFlagWrapper = styled.div`
     transition: transform 200ms;
   }
 
-  &:hover ${Flag} {
-    animation: ${wiggle} 1000ms;
-    animation-delay: 500ms;
+  @media (prefers-reduced-motion: no-preference) {
+    &:hover ${Flag} {
+      animation: ${wiggle} 1000ms;
+      animation-delay: 500ms;
+    }  
   }
 `;
 

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -77,10 +77,6 @@ const Link = styled.a`
 
 const Wrapper = styled.article``;
 
-const ImageAndFlagWrapper = styled.div`
-  position: relative;
-`;
-
 const ImageWrapper = styled.div`
   overflow: hidden;
   border-radius: 16px 16px 4px 4px;
@@ -94,8 +90,12 @@ const Image = styled.img`
   transform: scale(1) translateY(0);
   transition: transform 500ms;
   will-change: transform;
+`;
 
-  &:hover {
+const ImageAndFlagWrapper = styled.div`
+  position: relative;
+
+  &:hover ${Image} {
     transform: scale(1.1) translateY(-4px);
     transition: transform 200ms;
   }


### PR DESCRIPTION
Stretch goal for [Exercise 1: Sneaker Zoom](https://github.com/VrsajkovIvan33/sole-and-ankle-animated?tab=readme-ov-file#exercise-1-sneaker-zoom).

Add wiggle animation to the flag on hover, with a delay. Requires moving capturing the hover event on the wrapper for the image and flags instead of the image only.

![CleanShot 2024-09-26 at 17 18 52](https://github.com/user-attachments/assets/8047b41f-7406-4378-a4f4-23e8216632fe)
