### PR TITLE
Add nav link flip

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { QUERIES, WEIGHTS } from '../../constants';
+import { QUERIES } from '../../constants';
 import Logo from '../Logo';
 import Icon from '../Icon';
 import UnstyledButton from '../UnstyledButton';
 import SuperHeader from '../SuperHeader';
 import MobileMenu from '../MobileMenu';
 import VisuallyHidden from '../VisuallyHidden';
+import NavLink from './NavLink';
 
 const Header = () => {
   const [showMobileMenu, setShowMobileMenu] = React.useState(false);
@@ -111,18 +112,6 @@ const Filler = styled.div`
 
   @media ${QUERIES.tabletAndSmaller} {
     display: none;
-  }
-`;
-
-const NavLink = styled.a`
-  font-size: 1.125rem;
-  text-transform: uppercase;
-  text-decoration: none;
-  color: var(--color-gray-900);
-  font-weight: ${WEIGHTS.medium};
-
-  &:first-of-type {
-    color: var(--color-secondary);
   }
 `;
 

--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -6,22 +6,39 @@ const NavLink = ({ href, children }) => {
     return (
         <NavlinkWrapper>
             <Link href={href}>{children}</Link>
+            <BoldLink href={href}>{children}</BoldLink>
         </NavlinkWrapper>
     );
 }
 
 const Link = styled.a`
-  font-size: 1.125rem;
-  text-transform: uppercase;
-  text-decoration: none;
-  color: var(--color-gray-900);
-  font-weight: ${WEIGHTS.medium};
+    display: block;
+    font-size: 1.125rem;
+    text-transform: uppercase;
+    text-decoration: none;
+    color: var(--color-gray-900);
+    font-weight: ${WEIGHTS.medium};
+
+    transform: translateY(0);
+    transition: transform 200ms;
+`;
+
+const BoldLink = styled(Link)`
+    position: absolute;
+    font-weight: ${WEIGHTS.bold};
 `;
 
 const NavlinkWrapper = styled.div`
-  &:first-of-type > ${Link}  {
-    color: var(--color-secondary);
-  }
+    position: relative;
+    overflow: hidden;
+
+    &:first-of-type > ${Link}  {
+        color: var(--color-secondary);
+    }
+
+    &:hover > ${Link} {
+        transform: translateY(-100%);
+    }
 `;
 
 export default NavLink;

--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -21,6 +21,7 @@ const Link = styled.a`
 
     transform: translateY(0);
     transition: transform 200ms;
+    will-change: transform;
 `;
 
 const BoldLink = styled(Link)`

--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -1,0 +1,27 @@
+import styled from 'styled-components/macro';
+
+import { WEIGHTS } from '../../constants';
+
+const NavLink = ({ href, children }) => {
+    return (
+        <NavlinkWrapper>
+            <Link href={href}>{children}</Link>
+        </NavlinkWrapper>
+    );
+}
+
+const Link = styled.a`
+  font-size: 1.125rem;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--color-gray-900);
+  font-weight: ${WEIGHTS.medium};
+`;
+
+const NavlinkWrapper = styled.div`
+  &:first-of-type > ${Link}  {
+    color: var(--color-secondary);
+  }
+`;
+
+export default NavLink;


### PR DESCRIPTION
Submission for [Exercise 2: Navigation link flip up](https://github.com/VrsajkovIvan33/sole-and-ankle-animated?tab=readme-ov-file#exercise-2-navigation-link-flip-up).

- Extract Navlink component, adding a div wrapper above the anchor tag.
- Add second anchor with bold font weight, take it out of flow and hide overflow.
- Add animated transform moving both anchors up on hover on the wrapper, causing the flip effect.