### PR TITLE
Add mobile menu modal enter animation

### DIFF
--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -90,7 +90,8 @@ const ContentWrapper = styled(DialogContent)`
   animation-delay: 200ms;
 
   @media (prefers-reduced-motion: no-preference) {
-    animation: ${slideIn} 300ms;
+    animation: ${slideIn} 400ms;
+    animation-timing-function: cubic-bezier(.17,.67,.4,1);
   }
 `;
 
@@ -102,8 +103,7 @@ const Content = styled.div`
 
   animation: ${fadeIn} 400ms;
   animation-fill-mode: both;
-  animation-delay: 600ms;
-
+  animation-delay: 300ms;
 `;
 
 const CloseButton = styled(UnstyledButton)`

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
-import styled from 'styled-components/macro';
+import styled, { keyframes } from 'styled-components/macro';
 import { DialogOverlay, DialogContent } from '@reach/dialog';
 
 import { QUERIES, WEIGHTS } from '../../constants';
@@ -12,29 +12,41 @@ import VisuallyHidden from '../VisuallyHidden';
 const MobileMenu = ({ isOpen, onDismiss }) => {
   return (
     <Overlay isOpen={isOpen} onDismiss={onDismiss}>
-      <Content aria-label="Menu">
-        <CloseButton onClick={onDismiss}>
-          <Icon id="close" />
-          <VisuallyHidden>Dismiss menu</VisuallyHidden>
-        </CloseButton>
-        <Filler />
-        <Nav>
-          <NavLink href="/sale">Sale</NavLink>
-          <NavLink href="/new">New&nbsp;Releases</NavLink>
-          <NavLink href="/men">Men</NavLink>
-          <NavLink href="/women">Women</NavLink>
-          <NavLink href="/kids">Kids</NavLink>
-          <NavLink href="/collections">Collections</NavLink>
-        </Nav>
-        <Footer>
-          <SubLink href="/terms">Terms and Conditions</SubLink>
-          <SubLink href="/privacy">Privacy Policy</SubLink>
-          <SubLink href="/contact">Contact Us</SubLink>
-        </Footer>
-      </Content>
+      <DialogBackground />
+      <ContentWrapper>
+        <Content aria-label="Menu">
+          <CloseButton onClick={onDismiss}>
+            <Icon id="close" />
+            <VisuallyHidden>Dismiss menu</VisuallyHidden>
+          </CloseButton>
+          <Filler />
+          <Nav>
+            <NavLink href="/sale">Sale</NavLink>
+            <NavLink href="/new">New&nbsp;Releases</NavLink>
+            <NavLink href="/men">Men</NavLink>
+            <NavLink href="/women">Women</NavLink>
+            <NavLink href="/kids">Kids</NavLink>
+            <NavLink href="/collections">Collections</NavLink>
+          </Nav>
+          <Footer>
+            <SubLink href="/terms">Terms and Conditions</SubLink>
+            <SubLink href="/privacy">Privacy Policy</SubLink>
+            <SubLink href="/contact">Contact Us</SubLink>
+          </Footer>
+        </Content>
+      </ContentWrapper>
     </Overlay>
   );
 };
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`;
 
 const Overlay = styled(DialogOverlay)`
   position: fixed;
@@ -42,18 +54,56 @@ const Overlay = styled(DialogOverlay)`
   left: 0;
   right: 0;
   bottom: 0;
-  background: var(--color-backdrop);
+
   display: flex;
   justify-content: flex-end;
 `;
 
-const Content = styled(DialogContent)`
+const slideIn = keyframes`
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+`
+
+const DialogBackground = styled.div`
+  height: 100%;
+  width: 100%;
+  position: absolute;
+
+  background: var(--color-backdrop);
+
+  animation: ${fadeIn} 600ms;
+  animation-fill-mode: forwards;
+`;
+
+const ContentWrapper = styled(DialogContent)`
   background: white;
   width: 300px;
   height: 100%;
+  position: relative;
+
+  animation: ${fadeIn} 500ms;
+  animation-fill-mode: both;
+  animation-delay: 200ms;
+
+  @media (prefers-reduced-motion: no-preference) {
+    animation: ${slideIn} 300ms;
+  }
+`;
+
+const Content = styled.div`
   padding: 24px 32px;
+  height: 100%;
   display: flex;
   flex-direction: column;
+
+  animation: ${fadeIn} 400ms;
+  animation-fill-mode: both;
+  animation-delay: 600ms;
+
 `;
 
 const CloseButton = styled(UnstyledButton)`


### PR DESCRIPTION
Submission for [Exercise 3: Modal enter animation](https://github.com/VrsajkovIvan33/sole-and-ankle-animated?tab=readme-ov-file#exercise-3-modal-enter-animation).

Add sequenced animation for opening the modal:
- background fades in, 600ms,
- modal slides in, 400ms, delayed 200ms,
- content fades in, 400ms, delayed 300ms.

👆 The modal slide-in and content fade-in overlap, but it's not noticeable due to the [exaggerated ease-out timing function](https://cubic-bezier.com/#.17,.67,.4,1).

Required splitting the dark background from the overlay so that the `opacity` animation is not applied to the entire modal and all its content.

When "Reduced motion" is turned on, the modal also fades in instead of sliding in.

---

Demo:
![CleanShot 2024-09-26 at 19 15 15](https://github.com/user-attachments/assets/3b8e804f-1526-4fcd-8922-12815c030a0a)


