### PR TITLE
add aria-hidden and make bold links unfocusable

### DIFF
--- a/src/components/Header/NavLink.js
+++ b/src/components/Header/NavLink.js
@@ -6,7 +6,7 @@ const NavLink = ({ href, children }) => {
     return (
         <NavlinkWrapper>
             <Link href={href}>{children}</Link>
-            <BoldLink href={href}>{children}</BoldLink>
+            <BoldLink href={href} aria-label='hidden' tabIndex="-1">{children}</BoldLink>
         </NavlinkWrapper>
     );
 }


### PR DESCRIPTION
- Improve acessibility by removing the bold text from the screen reader.
- Hide bold text from being focused when using keyboard.